### PR TITLE
Update to latest version

### DIFF
--- a/.openzeppelin/unknown-27272.json
+++ b/.openzeppelin/unknown-27272.json
@@ -1,0 +1,94 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0x3C71cB925E5F4227D2793360a1149cc4fd450a91",
+      "txHash": "0xf9fd4d51d1c88327114c9394cf15fb58910d8fe3b15a175b092c56e25859ba9a",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "2b1ed6a27c817a8b7154a1877ca77bd9b7beea926b6ef180ff28010f7332dc08": {
+      "address": "0x93b09BE6dF10DA1F48Ad2db7c911a2f8c36739eC",
+      "txHash": "0x9df4a80d1ad7e15efc6d72e6e688334f24afcfac5663b0374ea08ef52f925eb5",
+      "layout": {
+        "solcVersion": "0.8.25",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/Aggregator.sol
+++ b/contracts/Aggregator.sol
@@ -3,7 +3,7 @@ pragma solidity =0.8.25;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
-import { IDiamondDao } from "./interfaces/IDao.sol";
+import { IDiamondDao } from "./interfaces/IDiamondDao.sol";
 import { IStakingHbbft } from "./interfaces/IStakingHbbft.sol";
 import { ITxPermission } from "./interfaces/ITxPermission.sol";
 import { IKeyGenHistory } from "./interfaces/IKeyGenHistory.sol";
@@ -101,12 +101,7 @@ contract DMDAggregator is Ownable {
         address[] voters;
         VotingResult votingResult;
         uint256 votersCount;
-    }
-
-    struct VotingStats {
-        address[] voters;
-        VotingResult votingResult;
-        uint256 votersCount;
+        uint256 totalDaoStake;
     }
 
     // SETTERS
@@ -263,22 +258,16 @@ contract DMDAggregator is Ownable {
         });
     }
 
-    function getVotingStats(uint256 proposalId) public view returns (VotingStats memory) {
-        return VotingStats({
-            voters: dao.getProposalVoters(proposalId),
-            votingResult: dao.countVotes(proposalId),
-            votersCount: dao.getProposalVotersCount(proposalId)
-        });
-    }
-
     function getProposalDetails(uint256 proposalId) public view returns (ProposalDetails memory) {
-        VotingStats memory votingStats = getVotingStats(proposalId);
+        Proposal memory proposal = dao.getProposal(proposalId);
+        uint256 totalDaoStake = dao.daoEpochTotalStakeSnapshot(proposal.daoPhaseCount);
 
         return ProposalDetails({
-            proposal: dao.getProposal(proposalId),
-            voters: votingStats.voters,
-            votingResult: votingStats.votingResult,
-            votersCount: votingStats.votersCount
+            proposal: proposal,
+            voters: dao.getProposalVoters(proposalId),
+            votingResult: dao.countVotes(proposalId),
+            votersCount: dao.getProposalVotersCount(proposalId),
+            totalDaoStake: totalDaoStake > 0 ? totalDaoStake : st.stakeAmountTotal(address(dao))
         });
     }
 

--- a/contracts/Aggregator.sol
+++ b/contracts/Aggregator.sol
@@ -281,8 +281,44 @@ contract DMDAggregator is Ownable {
         return proposals;
     }
 
-    function getActiveProposals() external view returns (ProposalDetails[] memory) {
+    function getActiveProposals() public view returns (ProposalDetails[] memory) {
         uint256[] memory activeProposals = dao.currentPhaseProposals();
         return getProposalsDetails(activeProposals);
+    }
+
+    function getDaoPhaseProposals(uint256 daoPhase) public view returns (ProposalDetails[] memory) {
+        uint256[] memory daoPhaseProposals = dao.daoPhaseProposals(daoPhase);
+        return getProposalsDetails(daoPhaseProposals);
+    }
+
+    function getHistoricProposals() external view returns (ProposalDetails[] memory) {
+        uint256 totalProposals = 0;
+        uint256 phaseCount = dao.daoPhaseCount();
+        
+        // First, count all proposals across all dao phases
+        for (uint256 i = 1; i <= phaseCount; i++) {
+            uint256[] memory proposalIds = dao.daoPhaseProposals(i);
+            totalProposals += proposalIds.length;
+        }
+        
+        uint256 index = 0;
+        ProposalDetails[] memory phaseProposals;
+        ProposalDetails[] memory historicProposals = new ProposalDetails[](totalProposals);
+
+        // Populate the historic proposals array
+        for (uint256 i = 1; i <= phaseCount; i++) {
+            if (i == phaseCount) {
+                phaseProposals = getActiveProposals();
+            } else {
+                phaseProposals = getDaoPhaseProposals(i);
+            }
+
+            for (uint256 j = 0; j < phaseProposals.length; j++) {
+                historicProposals[index] = phaseProposals[j];
+                index++;
+            }
+        }
+        
+        return historicProposals;
     }
 }

--- a/contracts/interfaces/IBonusScoreSystem.sol
+++ b/contracts/interfaces/IBonusScoreSystem.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity =0.8.25;
+
+interface IBonusScoreSystem {
+    function connectivityTracker() external view returns (address);
+    function getValidatorScore(address) external view returns (uint256);
+}

--- a/contracts/interfaces/IConnectivityTracker.sol
+++ b/contracts/interfaces/IConnectivityTracker.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity =0.8.25;
+
+interface IConnectivityTracker {
+    function isFaultyValidator(uint256,address) external view returns (bool);
+    function getValidatorConnectivityScore(uint256,address) external view returns (uint256);
+}

--- a/contracts/interfaces/IDao.sol
+++ b/contracts/interfaces/IDao.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity =0.8.25;
+
+import { DaoPhase, Phase, Proposal, ProposalState, Vote, VotingResult } from "../library/DaoStructs.sol";
+
+interface IDiamondDao {
+    event ProposalCreated(
+        address indexed proposer,
+        uint256 indexed proposalId,
+        address[] targets,
+        uint256[] values,
+        bytes[] calldatas,
+        string title,
+        string description,
+        string discussionUrl,
+        uint256 proposalFee
+    );
+
+    event ProposalCanceled(address indexed proposer, uint256 indexed proposalId, string reason);
+
+    event ProposalExecuted(address indexed caller, uint256 indexed proposalId);
+
+    event VotingFinalized(address indexed caller, uint256 indexed proposalId, bool indexed accepted);
+
+    event SubmitVote(address indexed voter, uint256 indexed proposalId, Vote indexed vote);
+
+    event SubmitVoteWithReason(
+        address indexed voter,
+        uint256 indexed proposalId,
+        Vote indexed vote,
+        string reason
+    );
+
+    event ChangeVote(address indexed voter, uint256 indexed proposalId, Vote indexed vote, string reason);
+
+    event SwitchDaoPhase(Phase indexed phase, uint256 indexed start, uint256 indexed end);
+
+    event SetCreateProposalFee(uint256 indexed fee);
+
+    event SetIsCoreContract(address indexed contractAddress, bool indexed isCore);
+
+    event SetChangeAbleParameters(bool indexed allowed, string setter, string getter, uint256[] params);
+
+    error InsufficientFunds();
+    error InvalidArgument();
+    error InvalidStartTimestamp();
+    error NewProposalsLimitExceeded();
+    error OnlyGovernance();
+    error OnlyProposer();
+    error OnlyValidators(address caller);
+    error ProposalAlreadyExist(uint256 proposalId);
+    error ProposalNotExist(uint256 proposalId);
+    error TransferFailed(address from, address to, uint256 amount);
+    error UnavailableInCurrentPhase(Phase phase);
+    error UnexpectedProposalState(uint256 proposalId, ProposalState state);
+    error ContractCallFailed(bytes funcSelector, address targetContract);
+    error UnfinalizedProposalsExist();
+    error OutsideExecutionWindow(uint256 proposalId);
+    error NotProposer(uint256 proposalId, address caller);
+    error SameVote(uint256 proposalId, address vote, Vote _vote);
+    error AlreadyVoted(uint256 proposalId, address voter);
+    error NoVoteFound(uint256 proposalId, address voter);
+
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory title,
+        string memory description,
+        string memory discussionUrl
+    ) external payable;
+
+    function cancel(uint256 proposalId, string calldata reason) external;
+
+    function vote(uint256 proposalId, Vote _vote) external;
+
+    function voteWithReason(uint256 proposalId, Vote _vote, string calldata reason) external;
+
+    function finalize(uint256 proposalId) external;
+
+    function execute(uint256 proposalId) external;
+
+    function proposalExists(uint256 proposalId) external view returns (bool);
+
+    function getProposal(uint256 proposalId) external view returns (Proposal memory);
+
+    function hashProposal(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory descriptionHash
+    ) external pure returns (uint256);
+
+    function daoPhaseCount() external view returns (uint256);
+
+    function daoPhase() external view returns (DaoPhase memory);
+
+    function createProposalFee() external view returns (uint256);
+
+    function getProposalVotersCount(uint256 proposalId) external view returns (uint256);
+
+    function countVotes(uint256 proposalId) external view returns (VotingResult memory);
+
+    function getProposalVoters(uint256 proposalId) external view returns (address[] memory);
+
+    function currentPhaseProposals() external view returns (uint256[] memory);
+}

--- a/contracts/interfaces/IDiamondDao.sol
+++ b/contracts/interfaces/IDiamondDao.sol
@@ -106,4 +106,6 @@ interface IDiamondDao {
     function currentPhaseProposals() external view returns (uint256[] memory);
 
     function daoEpochTotalStakeSnapshot(uint256 daoEpoch) external view returns (uint256);
+
+    function daoPhaseProposals(uint256 daoPhase) external view returns (uint256[] memory);
 }

--- a/contracts/interfaces/IDiamondDao.sol
+++ b/contracts/interfaces/IDiamondDao.sol
@@ -104,4 +104,6 @@ interface IDiamondDao {
     function getProposalVoters(uint256 proposalId) external view returns (address[] memory);
 
     function currentPhaseProposals() external view returns (uint256[] memory);
+
+    function daoEpochTotalStakeSnapshot(uint256 daoEpoch) external view returns (uint256);
 }

--- a/contracts/interfaces/IStakingHbbft.sol
+++ b/contracts/interfaces/IStakingHbbft.sol
@@ -10,13 +10,17 @@ interface IStakingHbbft {
     function stakingEpochStartBlock() external view returns (uint256);
     function areStakeAndWithdrawAllowed() external view returns (bool);
     function stakeAmountTotal(address) external view returns (uint256);
+    function poolNodeOperator(address) external view returns (address);
     function stakingFixedEpochEndTime() external view returns (uint256);
     function getPoolsInactive() external view returns (address[] memory);
     function stakingFixedEpochDuration() external view returns (uint256);
     function stakeAmount(address, address) external view returns (uint256);
     function getPoolsToBeElected() external view returns (address[] memory);
+    function poolNodeOperatorShare(address) external view returns (uint256);
     function stakingWithdrawDisallowPeriod() external view returns (uint256);
     function poolDelegators(address) external view returns (address[] memory);
     function orderWithdrawEpoch(address, address) external view returns (uint256);
+    function maxWithdrawAllowed(address, address) external view returns (uint256);
     function orderedWithdrawAmount(address, address) external view returns (uint256);
+    function maxWithdrawOrderAllowed(address, address) external view returns (uint256);
 }

--- a/contracts/interfaces/IValidatorSetHbbft.sol
+++ b/contracts/interfaces/IValidatorSetHbbft.sol
@@ -11,6 +11,8 @@ interface IValidatorSetHbbft {
         AllKeysDone
     }
 
+    function bonusScoreSystem() external view returns(address);
+
     function blockRewardContract() external view returns(address);
     function keyGenHistoryContract() external view returns(address);
 

--- a/contracts/library/DaoStructs.sol
+++ b/contracts/library/DaoStructs.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity =0.8.25;
+
+enum ProposalState {
+    Created,
+    Canceled,
+    Active,
+    VotingFinished,
+    Accepted,
+    Declined,
+    Executed
+}
+
+enum Vote {
+    No,
+    Yes
+}
+
+enum Phase {
+    Proposal,
+    Voting
+}
+
+enum ProposalType {
+    Open,
+    ContractUpgrade,
+    EcosystemParameterChange
+}
+
+struct DaoPhase {
+    uint64 start;
+    uint64 end;
+    uint64 daoEpoch;
+    Phase phase;
+}
+
+struct VoteRecord {
+    uint64 timestamp;
+    Vote vote;
+    string reason;
+}
+
+struct VotingResult {
+    uint64 countYes;
+    uint64 countNo;
+    uint256 stakeYes;
+    uint256 stakeNo;
+}
+
+struct Proposal {
+    address proposer;
+    uint64 votingDaoEpoch;
+    ProposalState state;
+    address[] targets;
+    uint256[] values;
+    bytes[] calldatas;
+    string title;
+    string description;
+    string discussionUrl;
+    uint256 daoPhaseCount;
+    uint256 proposalFee;
+    ProposalType proposalType;
+}
+
+struct ProposalStatistic {
+    uint64 total;
+    uint64 accepted;
+    uint64 declined;
+    uint64 canceled;
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import * as fs from "fs";
 import { ethers } from "ethers";
 import { HardhatUserConfig } from "hardhat/config";
 
@@ -20,6 +20,8 @@ const mnemonic: string = process.env.MNEMONIC ? process.env.MNEMONIC : ethers.Mn
 const chainIds = {
   hardhat: 31337,
   alpha4: 777018,
+  alpha5: 777019,
+  beta: 27272,
 };
 
 const config: HardhatUserConfig = {
@@ -47,16 +49,27 @@ const config: HardhatUserConfig = {
       },
       gasPrice: 1000000000,
     },
+    beta: {
+      url: "https://beta-rpc.bit.diamonds",
+      accounts: {
+        mnemonic: getMnemonic(),
+        path: "m/44'/60'/0'/0",
+        initialIndex: 0,
+        count: 20,
+        passphrase: "",
+      },
+      gasPrice: 1000000000,
+    },
   },
   etherscan: {
     apiKey: "123",
     customChains: [
       {
-        network: "alpha4",
-        chainId: 777018,
+        network: "beta",
+        chainId: 27272,
         urls: {
-            apiURL: "http://62.171.133.46:4400/api",
-            browserURL: "http://62.171.133.46:4400",
+          apiURL: "http://62.84.188.137/api",
+          browserURL: "http://62.84.188.137",
         },
       },
     ],

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -68,8 +68,8 @@ const config: HardhatUserConfig = {
         network: "beta",
         chainId: 27272,
         urls: {
-          apiURL: "http://62.84.188.137/api",
-          browserURL: "http://62.84.188.137",
+          apiURL: "https://beta-explorer.bit.diamonds/api",
+          browserURL: "https://beta-explorer.bit.diamonds",
         },
       },
     ],

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -11,6 +11,7 @@ async function deploy() {
     '0x1100000000000000000000000000000000000001',  // Staking
     '0x1000000000000000000000000000000000000001',   // ValidatorSet
     '0x4000000000000000000000000000000000000001', // TxPermisson
+    '0xDA0da0da0Da0Da0Da0DA00DA0da0da0DA0DA0dA0' // DAO
   ];
 
   // Deploy the DMDAggregator contract
@@ -19,7 +20,8 @@ async function deploy() {
     args[0],
     args[1],
     args[2],
-    args[3]
+    args[3],
+    args[4]
   );
 
   await dmdAggregator.waitForDeployment();

--- a/scripts/deployForChainSpec.ts
+++ b/scripts/deployForChainSpec.ts
@@ -13,14 +13,15 @@ async function deployForChainspec() {
     const initialOwner = deployer.address;
     const staking = '0x1100000000000000000000000000000000000001'; // Staking
     const validatorSet = '0x1000000000000000000000000000000000000001'; // ValidatorSet
-    const txPermisson = '0x4000000000000000000000000000000000000001' // TxPermisson
+    const txPermisson = '0x4000000000000000000000000000000000000001'; // TxPermisson
+    const dao = '0xDA0da0da0Da0Da0Da0DA00DA0da0da0DA0DA0dA0'; // DAO
 
     let spec: { [id: string]: ContractSpec; } = {};
 
     const aggregatorAddress = "0x9990000000000000000000000000000000000000";
     spec[aggregatorAddress] = {
         balance: "0",
-        constructor: (await dmdAggregatorFactory.getDeployTransaction(initialOwner, staking, validatorSet, txPermisson)).data
+        constructor: (await dmdAggregatorFactory.getDeployTransaction(initialOwner, staking, validatorSet, txPermisson, dao)).data
     };
 
     if (!fs.existsSync("out")) {

--- a/scripts/deployProxy.ts
+++ b/scripts/deployProxy.ts
@@ -10,7 +10,8 @@ async function deploy() {
     deployer.address, // Initial Owner
     '0x1100000000000000000000000000000000000001', // Staking
     '0x1000000000000000000000000000000000000001', // ValidatorSet
-    '0x4000000000000000000000000000000000000001' // TxPermisson
+    '0x4000000000000000000000000000000000000001', // TxPermisson
+    '0xDA0da0da0Da0Da0Da0DA00DA0da0da0DA0DA0dA0' // DAO
   ]
 
   // Deploy the DMDAggregator contract using a proxy for upgradeability

--- a/scripts/deployProxyForChainSpec.ts
+++ b/scripts/deployProxyForChainSpec.ts
@@ -28,7 +28,8 @@ async function compileProxy() {
         deployer.address, // Initial Owner
         '0x1100000000000000000000000000000000000001', // Staking
         '0x1000000000000000000000000000000000000001', // ValidatorSet
-        '0x4000000000000000000000000000000000000001' // TxPermisson
+        '0x4000000000000000000000000000000000000001', // TxPermisson
+        '0xDA0da0da0Da0Da0Da0DA00DA0da0da0DA0DA0dA0' // DAO
     ];
 
     console.log("Initializer Arguments:", aggregatorInitArgs);


### PR DESCRIPTION
This pull request introduces several major enhancements and integrations to the `DMDAggregator` contract and its supporting infrastructure. The most significant changes include deeper integration with DAO and validator scoring systems, the addition of new interfaces, and the expansion of contract methods to provide richer data access for node operators and proposals. These updates enable more comprehensive tracking of validator performance and DAO governance activities.

**DAO Integration and Proposal Management:**
* Integrated the `IDiamondDao` interface into `DMDAggregator` and expanded the constructor to accept a DAO address. Added methods for retrieving DAO globals, proposal details, active proposals, proposals by phase, and historic proposals, leveraging new data structures from `DaoStructs.sol`. [[1]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R6-R34) [[2]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2L79-R104) [[3]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R238-R323)

**Validator Scoring and Connectivity Enhancements:**
* Added support for validator scoring and connectivity tracking by integrating the `IBonusScoreSystem` and `IConnectivityTracker` interfaces. `PoolData` now includes `isFaultyValidator`, `validatorScore`, and `connectivityScore` fields, populated using new contract calls. [[1]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R6-R34) [[2]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R70-R72) [[3]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R151-R162) [[4]](diffhunk://#diff-81ee3975871cf72c0fb0b4e2852a6dd7cac03f4136fa5935adc8ea8fb7494e1eR1-R7) [[5]](diffhunk://#diff-db248c8949b558ce9212267961d18d2157c35c825ee2850765883b4ba707ba8fR1-R7)

**Interface and Struct Refactoring:**
* Moved DAO-related enums and structs (such as `ProposalState`, `ProposalType`, `DaoPhase`, `VotingResult`, etc.) to a new `library/DaoStructs.sol` file for better modularity and reusability. Updated references throughout the aggregator and interfaces. [[1]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R6-R34) [[2]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2L79-R104) [[3]](diffhunk://#diff-a4d85baa089b1e9ec9f77898ecb6fcfc7b6b0e6fa7dc754e6ba495f7150645b0R1-R70) [[4]](diffhunk://#diff-8d9aaa136c56f84482f50af05905510e8d37491e527f48b2274fc0da23d6fdd2R1-R111)

**Expanded Staking and Node Operator Data Access:**
* Enhanced `IStakingHbbft` and `IValidatorSetHbbft` interfaces with new methods for accessing node operator info, withdrawable amounts, and bonus score system address. Added corresponding read methods to `DMDAggregator`. [[1]](diffhunk://#diff-9a4ff61df9a4f5a5a0bc23f7dd7b34300eb7cd8ce1ca2c89f8a33f239bcc4a05R13-R25) [[2]](diffhunk://#diff-10836979c3e8781d1c5446281e32f40b5529ba58b4fb38071358ab5f5b31bdfaR14-R15) [[3]](diffhunk://#diff-62b22dfa2e988937a670df536031430b49c517a3bf3076d9979314e8e22ed7d2R238-R323)

**Configuration and Deployment Updates:**
* Updated Hardhat configuration to support the new `beta` network, including RPC and explorer URLs, and added the DAO contract address to deployment scripts. [[1]](diffhunk://#diff-57cf5378f8cab20b02b279097ba6fad08eb53f747d81770045dda9c5f95effe3L1-R1) [[2]](diffhunk://#diff-57cf5378f8cab20b02b279097ba6fad08eb53f747d81770045dda9c5f95effe3R23-R24) [[3]](diffhunk://#diff-57cf5378f8cab20b02b279097ba6fad08eb53f747d81770045dda9c5f95effe3R52-R72) [[4]](diffhunk://#diff-2cf9c5908dc8ce42e9ef5fcabb812f770e3648e84af9535aea9a331773e3e5b0R14) [[5]](diffhunk://#diff-2cf9c5908dc8ce42e9ef5fcabb812f770e3648e84af9535aea9a331773e3e5b0L22-R24)

**Other:**
* Added a new OpenZeppelin manifest file for the beta network deployment. (.openzeppelin/unknown-27272.json)